### PR TITLE
Update nf-core subworkflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [30](https://github.com/nf-core/rangeland/pull/30) Template update for nf-core/tools v3.4.1
 - [32](https://github.com/nf-core/rangeland/pull/32) Template update for nf-core/tools v3.5.1
 - [33](https://github.com/nf-core/rangeland/pull/33) Nextflow strict syntax update
+- [34](https://github.com/nf-core/rangeland/pull/34) Update nf-core subworkflows
 
 ### `Fixed`
 

--- a/modules.json
+++ b/modules.json
@@ -26,12 +26,12 @@
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
-                        "git_sha": "271e7fc14eb1320364416d996fb077421f3faed2",
+                        "git_sha": "65f5e638d901a51534c68fd5c1c19e8112fb4df1",
                         "installed_by": ["subworkflows"]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
-                        "git_sha": "4b406a74dc0449c0401ed87d5bfff4252fd277fd",
+                        "git_sha": "fdc08b8b1ae74f56686ce21f7ea11ad11990ce57",
                         "installed_by": ["subworkflows"]
                     }
                 }

--- a/subworkflows/nf-core/utils_nfschema_plugin/main.nf
+++ b/subworkflows/nf-core/utils_nfschema_plugin/main.nf
@@ -38,7 +38,7 @@ workflow UTILS_NFSCHEMA_PLUGIN {
         }
         log.info paramsHelp(
             help_options,
-            params.help instanceof String ? params.help : "",
+            (params.help instanceof String && params.help != "true") ? params.help : "",
         )
         exit 0
     }
@@ -71,4 +71,3 @@ workflow UTILS_NFSCHEMA_PLUGIN {
     emit:
     dummy_emit = true
 }
-

--- a/subworkflows/nf-core/utils_nfschema_plugin/tests/nextflow.config
+++ b/subworkflows/nf-core/utils_nfschema_plugin/tests/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-    id "nf-schema@2.5.1"
+    id "nf-schema@2.6.1"
 }
 
 validation {


### PR DESCRIPTION
This PR updates the `utils_nfcore_pipeline` and `utils_nfschema_plugin` in order to fix the generation of the help message generated by `nextflow run . --help` with strict syntax enabled.